### PR TITLE
Allow injecting custom interface factory

### DIFF
--- a/src/clean_interfaces/app.py
+++ b/src/clean_interfaces/app.py
@@ -28,7 +28,11 @@ from clean_interfaces.utils.settings import get_interface_settings, get_settings
 class Application:
     """Main application class that orchestrates components."""
 
-    def __init__(self, dotenv_path: Path | None = None) -> None:
+    def __init__(
+        self,
+        dotenv_path: Path | None = None,
+        interface_factory: InterfaceFactory | None = None,
+    ) -> None:
         """Initialize the application.
 
         Args:
@@ -54,7 +58,7 @@ class Application:
         self.logger = get_logger(__name__)
 
         # Initialize interface
-        self.interface_factory = InterfaceFactory()
+        self.interface_factory = interface_factory or InterfaceFactory()
         self.interface = self.interface_factory.create_from_settings()
 
         self.logger.info(
@@ -165,7 +169,11 @@ def run_hpo_with_reflection(
     return result, reflection
 
 
-def create_app(dotenv_path: Path | None = None) -> Application:
+def create_app(
+    dotenv_path: Path | None = None,
+    *,
+    interface_factory: InterfaceFactory | None = None,
+) -> Application:
     """Create an application instance.
 
     Args:
@@ -175,15 +183,25 @@ def create_app(dotenv_path: Path | None = None) -> Application:
         Application: Configured application instance
 
     """
-    return Application(dotenv_path=dotenv_path)
+    return Application(
+        dotenv_path=dotenv_path,
+        interface_factory=interface_factory,
+    )
 
 
-def run_app(dotenv_path: Path | None = None) -> None:
+def run_app(
+    dotenv_path: Path | None = None,
+    *,
+    interface_factory: InterfaceFactory | None = None,
+) -> None:
     """Create and run the application.
 
     Args:
         dotenv_path: Optional path to .env file to load
 
     """
-    app = create_app(dotenv_path=dotenv_path)
+    app = create_app(
+        dotenv_path=dotenv_path,
+        interface_factory=interface_factory,
+    )
     app.run()

--- a/tests/unit/clean_interfaces/test_app.py
+++ b/tests/unit/clean_interfaces/test_app.py
@@ -89,6 +89,50 @@ class TestApplication:
     @patch("clean_interfaces.app.get_settings")
     @patch("clean_interfaces.app.get_interface_settings")
     @patch("clean_interfaces.app.InterfaceFactory")
+    def test_application_initialization_with_custom_factory(
+        self,
+        mock_factory_class: MagicMock,
+        mock_get_interface_settings: MagicMock,
+        mock_get_settings: MagicMock,
+        mock_get_logger: MagicMock,
+        mock_configure_logging: MagicMock,  # noqa: ARG002
+        mock_load_dotenv: MagicMock,  # noqa: ARG002
+    ) -> None:
+        """Custom interface factories should be used when provided."""
+
+        mock_factory_class.return_value = MagicMock()
+
+        mock_settings = MagicMock()
+        mock_settings.log_level = "INFO"
+        mock_settings.log_format = "json"
+        mock_settings.log_file_path = None
+        mock_get_settings.return_value = mock_settings
+
+        mock_interface_settings = MagicMock()
+        mock_interface_settings.model_dump.return_value = {"interface_type": "custom"}
+        mock_get_interface_settings.return_value = mock_interface_settings
+
+        mock_interface = MagicMock()
+        mock_interface.name = "Custom"
+        custom_factory = MagicMock()
+        custom_factory.create_from_settings.return_value = mock_interface
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+
+        app = Application(interface_factory=custom_factory)
+
+        custom_factory.create_from_settings.assert_called_once()
+        assert app.interface is mock_interface
+        assert app.interface_factory is custom_factory
+        mock_factory_class.assert_not_called()
+
+    @patch("clean_interfaces.app.load_dotenv")
+    @patch("clean_interfaces.app.configure_logging")
+    @patch("clean_interfaces.app.get_logger")
+    @patch("clean_interfaces.app.get_settings")
+    @patch("clean_interfaces.app.get_interface_settings")
+    @patch("clean_interfaces.app.InterfaceFactory")
     def test_application_initialization_with_dotenv(
         self,
         mock_factory_class: MagicMock,
@@ -319,7 +363,7 @@ def test_create_app() -> None:
         result = create_app()
 
         assert result == mock_app
-        mock_app_class.assert_called_once_with(dotenv_path=None)
+        mock_app_class.assert_called_once_with(dotenv_path=None, interface_factory=None)
 
 
 def test_create_app_with_dotenv() -> None:
@@ -334,7 +378,10 @@ def test_create_app_with_dotenv() -> None:
         result = create_app(dotenv_path=dotenv_path)
 
         assert result == mock_app
-        mock_app_class.assert_called_once_with(dotenv_path=dotenv_path)
+        mock_app_class.assert_called_once_with(
+            dotenv_path=dotenv_path,
+            interface_factory=None,
+        )
 
 
 def test_run_app() -> None:
@@ -345,7 +392,10 @@ def test_run_app() -> None:
 
         run_app()
 
-        mock_create_app.assert_called_once_with(dotenv_path=None)
+        mock_create_app.assert_called_once_with(
+            dotenv_path=None,
+            interface_factory=None,
+        )
         mock_app.run.assert_called_once()
 
 
@@ -360,5 +410,8 @@ def test_run_app_with_dotenv() -> None:
 
         run_app(dotenv_path=dotenv_path)
 
-        mock_create_app.assert_called_once_with(dotenv_path=dotenv_path)
+        mock_create_app.assert_called_once_with(
+            dotenv_path=dotenv_path,
+            interface_factory=None,
+        )
         mock_app.run.assert_called_once()


### PR DESCRIPTION
## Summary
- allow Application to accept an optional interface factory and use it when provided
- plumb the factory argument through create_app/run_app and expand tests for custom factories

## Testing
- pytest tests/unit/clean_interfaces/test_app.py

------
https://chatgpt.com/codex/tasks/task_e_68ce3c4f7520833080636fb0b87712e4