### PR TITLE
Add DefaultTrialExecutor wrapper supporting dataset injection

### DIFF
--- a/src/clean_interfaces/hpo/__init__.py
+++ b/src/clean_interfaces/hpo/__init__.py
@@ -10,7 +10,7 @@ from .configuration import (
     default_tuning_config,
     load_tuning_config,
 )
-from .executors import default_trial_executor
+from .executors import DefaultTrialExecutor, default_trial_executor
 from .logging import CSVTrialLogger, HPOTrialLogger
 from .orchestrator import HPOOrchestrator, TrialExecutorProtocol
 from .reflection import ReflectionAgent
@@ -52,6 +52,7 @@ __all__ = [
     "TrialObservation",
     "TuningConfig",
     "TuningParameterDefinition",
+    "DefaultTrialExecutor",
     "build_application_plan",
     "default_trial_executor",
     "default_tuning_config",

--- a/src/clean_interfaces/interfaces/cli.py
+++ b/src/clean_interfaces/interfaces/cli.py
@@ -18,7 +18,7 @@ from clean_interfaces.hpo.configuration import (
     default_tuning_config,
     load_tuning_config,
 )
-from clean_interfaces.hpo.executors import default_trial_executor
+from clean_interfaces.hpo.executors import DefaultTrialExecutor
 from clean_interfaces.hpo.schemas import (
     CodingTask,
     HPOExecutionRequest,
@@ -306,8 +306,9 @@ class CLIInterface(BaseInterface):
                 progress,
                 total_trials=config.max_trials,
             )
+            trial_executor = DefaultTrialExecutor()
             orchestrator = create_hpo_orchestrator(
-                trial_executor=default_trial_executor,
+                trial_executor=trial_executor,
                 trial_logger=trial_logger,
             )
             result = orchestrator.optimize(task, search_space, config)
@@ -368,9 +369,10 @@ class CLIInterface(BaseInterface):
                 progress,
                 total_trials=config.max_trials,
             )
+            trial_executor = DefaultTrialExecutor()
             result, reflection = run_hpo_with_reflection(
                 execution_request,
-                trial_executor=default_trial_executor,
+                trial_executor=trial_executor,
                 mode=reflection_mode,
                 trial_logger=trial_logger,
             )

--- a/src/clean_interfaces/interfaces/mcp.py
+++ b/src/clean_interfaces/interfaces/mcp.py
@@ -3,7 +3,7 @@
 from fastmcp import FastMCP
 
 from clean_interfaces.hpo.configuration import default_tuning_config
-from clean_interfaces.hpo.executors import default_trial_executor
+from clean_interfaces.hpo.executors import DefaultTrialExecutor
 from clean_interfaces.hpo.schemas import (
     CodingTask,
     HPOExecutionRequest,
@@ -79,9 +79,10 @@ class MCPInterface(BaseInterface):
 
             from clean_interfaces.app import run_hpo_with_reflection
 
+            trial_executor = DefaultTrialExecutor()
             result, reflection = run_hpo_with_reflection(
                 request,
-                trial_executor=default_trial_executor,
+                trial_executor=trial_executor,
                 mode=reflection_mode,
             )
 

--- a/src/clean_interfaces/interfaces/restapi.py
+++ b/src/clean_interfaces/interfaces/restapi.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from clean_interfaces.hpo.executors import default_trial_executor
+from clean_interfaces.hpo.executors import DefaultTrialExecutor
 from clean_interfaces.hpo.schemas import HPOExecutionRequest, HPOExecutionResponse
 from clean_interfaces.models.api import (
     HealthResponse,
@@ -90,9 +90,10 @@ class RestAPIInterface(BaseInterface):
             """Launch a hyperparameter optimization run."""
             from clean_interfaces.app import run_hpo_experiment
 
+            trial_executor = DefaultTrialExecutor()
             result = run_hpo_experiment(
                 request,
-                trial_executor=default_trial_executor,
+                trial_executor=trial_executor,
             )
             return HPOExecutionResponse(**result.model_dump())
 


### PR DESCRIPTION
## Summary
- wrap the default trial executor logic inside a DefaultTrialExecutor callable that can accept custom golden datasets and evaluation services
- update CLI, REST API, and MCP interfaces to pass executor instances into orchestrator helpers
- extend unit tests to cover injecting a bespoke dataset into the executor

## Testing
- pytest tests/unit/clean_interfaces/hpo/test_executors.py

------
https://chatgpt.com/codex/tasks/task_e_68ce3c4e301c83309183ebf93a05b55f